### PR TITLE
[Feat/#24] setting swagger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
 	runtimeOnly 'io.jsonwebtoken:jjwt-gson:0.11.5'
 }

--- a/src/main/java/com/rockoon/domain/board/controller/PromotionApiController.java
+++ b/src/main/java/com/rockoon/domain/board/controller/PromotionApiController.java
@@ -7,7 +7,13 @@ import com.rockoon.domain.board.service.promotion.PromotionCommandService;
 import com.rockoon.domain.board.service.promotion.PromotionQueryService;
 import com.rockoon.domain.member.entity.Member;
 import com.rockoon.domain.member.service.MemberQueryService;
+import com.rockoon.global.annotation.api.ApiErrorCodeExample;
+import com.rockoon.global.annotation.auth.AuthUser;
+import com.rockoon.presentation.payload.code.ErrorStatus;
 import com.rockoon.presentation.payload.dto.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +21,8 @@ import org.springframework.web.bind.annotation.*;
 
 import static com.rockoon.domain.board.dto.promotion.PromotionResponse.PromotionDetailDto;
 
+@Tag(name = "Promotion API", description = "프로모션 API")
+@ApiResponse(responseCode = "2000", description = "성공")
 @RequestMapping("/api/promotions")
 @RequiredArgsConstructor
 @RestController
@@ -23,21 +31,41 @@ public class PromotionApiController {
     private final PromotionQueryService promotionQueryService;
     private final MemberQueryService memberQueryService;
 
-    @PostMapping("/{memberId}")     //TODO remove pathVariable and use @AuthUser
-    public ApiResponseDto<Long> createPromotion(@PathVariable Long memberId,
+    @Operation(summary = "프로모션 작성 🔑", description = "로그인한 회원이 프로모션(홍보글)을 작성합니다.")
+    @ApiErrorCodeExample({
+            ErrorStatus._INTERNAL_SERVER_ERROR,
+            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
+            ErrorStatus._ASSIGNABLE_PARAMETER,
+            ErrorStatus.MEMBER_NOT_FOUND
+    })
+    @PostMapping
+    public ApiResponseDto<Long> createPromotion(@AuthUser Member member,
                                                 @RequestBody PromotionRequest promotionRequest) {
-        Member member = memberQueryService.getByMemberId(memberId);
         return ApiResponseDto.onSuccess(promotionCommandService.createPromotion(member, promotionRequest));
     }
 
-    @PutMapping("/{promotionId}/members/{memberId}")       //TODO remove memberId pathVariable
-    public ApiResponseDto<Long> modifyPromotion(@PathVariable Long memberId,
+    @Operation(summary = "프로모션 수정 🔑", description = "로그인한 회원이 프로모션(홍보글)을 작성했던 글을 수정합니다." +
+            "권한은 작성자에게만 있습니다.")
+    @ApiErrorCodeExample({
+            ErrorStatus._INTERNAL_SERVER_ERROR,
+            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
+            ErrorStatus._ASSIGNABLE_PARAMETER,
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.PROMOTION_NOT_FOUND,
+            ErrorStatus.PROMOTION_ONLY_CAN_BE_TOUCHED_BY_WRITER
+    })
+    @PutMapping("/{promotionId}")
+    public ApiResponseDto<Long> modifyPromotion(@AuthUser Member member,
                                                 @PathVariable Long promotionId,
                                                 @RequestBody PromotionRequest promotionRequest) {
-        Member member = memberQueryService.getByMemberId(memberId);
         return ApiResponseDto.onSuccess(promotionCommandService.modifyPromotion(member, promotionId, promotionRequest));
     }
 
+    @Operation(summary = "프로모션 조회", description = "프로모션의 PK를 통해 글을 조회합니다.")
+    @ApiErrorCodeExample({
+            ErrorStatus._INTERNAL_SERVER_ERROR,
+            ErrorStatus.PROMOTION_NOT_FOUND
+    })
     @GetMapping("/{promotionId}")
     public ApiResponseDto<PromotionDetailDto> getPromotionById(@PathVariable Long promotionId) {
         return ApiResponseDto.onSuccess(
@@ -47,6 +75,12 @@ public class PromotionApiController {
         );
     }
 
+    @Operation(summary = "프로모션 페이징 조회", description = "프로모션의 리스트를 페이징을 통해 조회합니다." +
+            "한페이지당 사이즈는 5개입니다.")
+    @ApiErrorCodeExample({
+            ErrorStatus._INTERNAL_SERVER_ERROR,
+            ErrorStatus.PROMOTION_NOT_FOUND
+    })
     @GetMapping
     public ApiResponseDto<PromotionListDto> getPromotionList(@RequestParam(defaultValue = "0") int currentPage) {
         Pageable pageable = PageRequest.of(currentPage, 5);
@@ -57,10 +91,19 @@ public class PromotionApiController {
         );
     }
 
-    @DeleteMapping("/{promotionId}/members/{memberId}")
-    public ApiResponseDto<Boolean> deletePromotion(@PathVariable Long memberId,
+    @Operation(summary = "프로모션 삭제 🔑", description = "로그인한 회원이 프로모션(홍보글)을 작성했던 글을 삭제합니다." +
+            "권한은 작성자에게만 있습니다.")
+    @ApiErrorCodeExample({
+            ErrorStatus._INTERNAL_SERVER_ERROR,
+            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
+            ErrorStatus._ASSIGNABLE_PARAMETER,
+            ErrorStatus.MEMBER_NOT_FOUND,
+            ErrorStatus.PROMOTION_NOT_FOUND,
+            ErrorStatus.PROMOTION_ONLY_CAN_BE_TOUCHED_BY_WRITER
+    })
+    @DeleteMapping("/{promotionId}")
+    public ApiResponseDto<Boolean> deletePromotion(@AuthUser Member member,
                                                    @PathVariable Long promotionId) {
-        Member member = memberQueryService.getByMemberId(memberId);
         promotionCommandService.removePromotion(member, promotionId);
         return ApiResponseDto.onSuccess(true);
     }

--- a/src/main/java/com/rockoon/domain/member/controller/MemberApiController.java
+++ b/src/main/java/com/rockoon/domain/member/controller/MemberApiController.java
@@ -7,11 +7,18 @@ import com.rockoon.domain.member.dto.MemberResponse;
 import com.rockoon.domain.member.entity.Member;
 import com.rockoon.domain.member.service.MemberCommandService;
 import com.rockoon.domain.member.service.MemberQueryService;
+import com.rockoon.global.annotation.api.ApiErrorCodeExample;
 import com.rockoon.global.annotation.auth.AuthUser;
+import com.rockoon.presentation.payload.code.ErrorStatus;
 import com.rockoon.presentation.payload.dto.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Member API", description = "회원 API")
+@ApiResponse(responseCode = "2000", description = "성공")
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
 @RestController
@@ -19,17 +26,35 @@ public class MemberApiController {
     private final MemberCommandService memberCommandService;
     private final MemberQueryService memberQueryService;
 
+    @Operation(summary = "회원가입", description = "회원정보를 통해 서버 내 회원가입을 진행합니다. " +
+            "kakaoEmail, profileImg, nickname, name의 정보를 받습니다.")
+    @ApiErrorCodeExample({
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
     @PostMapping
     public ApiResponseDto<Long> registerMember(@RequestBody MemberRegisterDto memberRegisterDto) {
         return ApiResponseDto.onSuccess(memberCommandService.registerMember(memberRegisterDto));
     }
 
+    @Operation(summary = "회원 정보 수정 🔑", description = "로그인한 회원의 정보를 수정합니다. " +
+            "profileImg, nickname, name을 변경할 수 있습니다.")
+    @ApiErrorCodeExample({
+            ErrorStatus._INTERNAL_SERVER_ERROR,
+            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
+            ErrorStatus._ASSIGNABLE_PARAMETER,
+            ErrorStatus.MEMBER_NOT_FOUND
+    })
     @PutMapping
     public ApiResponseDto<Long> modifyMemberInfo(@AuthUser Member member,
                                                  @RequestBody MemberModifyDto memberModifyDto) {
         return ApiResponseDto.onSuccess(memberCommandService.modifyMemberInfo(member, memberModifyDto));
     }
 
+    @Operation(summary = "회원 정보 조회 🔑", description = "PK를 통해 사용자의 정보를 조회합니다.")
+    @ApiErrorCodeExample({
+            ErrorStatus._INTERNAL_SERVER_ERROR,
+            ErrorStatus.MEMBER_NOT_FOUND
+    })
     @GetMapping("/{memberId}")
     public ApiResponseDto<MemberResponse> getMemberInfo(@PathVariable Long memberId) {
         return ApiResponseDto.onSuccess(

--- a/src/main/java/com/rockoon/global/annotation/api/ApiErrorCodeExample.java
+++ b/src/main/java/com/rockoon/global/annotation/api/ApiErrorCodeExample.java
@@ -1,0 +1,14 @@
+package com.rockoon.global.annotation.api;
+
+import com.rockoon.presentation.payload.code.ErrorStatus;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExample {
+    ErrorStatus[] value();
+}

--- a/src/main/java/com/rockoon/global/annotation/auth/AuthUser.java
+++ b/src/main/java/com/rockoon/global/annotation/auth/AuthUser.java
@@ -1,10 +1,12 @@
 package com.rockoon.global.annotation.auth;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 import java.lang.annotation.*;
 
 @Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-//@Parameter(hidden=true)      TODO swagger 사용 시 설정 해주기
+@Parameter(hidden=true)
 @Documented
 public @interface AuthUser {
     boolean errorOnInvalidType() default true;

--- a/src/main/java/com/rockoon/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/rockoon/global/config/swagger/SwaggerConfig.java
@@ -1,0 +1,138 @@
+package com.rockoon.global.config.swagger;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rockoon.global.annotation.api.ApiErrorCodeExample;
+import com.rockoon.presentation.payload.code.ErrorStatus;
+import com.rockoon.presentation.payload.code.Reason;
+import com.rockoon.presentation.payload.dto.ApiResponseDto;
+import com.rockoon.presentation.payload.holder.ExampleHolder;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.groupingBy;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI api() {
+        Info info = new Info()
+                .version("v1.0.0")
+                .title("Play-BarCode API Document")
+                .description("""
+                        ## Play-BarCode API 명세서입니다. 🐾
+                                                
+                        ---
+                                                
+                        ### 🔑 테스트 사용자 인증 토큰
+                        `[null]`
+                                                
+                        """);
+
+        String jwtSchemeName = "JWT";
+
+        // API 요청헤더에 인증정보 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        // SecuritySchemes 등록
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .in(SecurityScheme.In.HEADER)
+                        .bearerFormat("Authorization"));
+
+        Server server = new Server().url("/");
+
+        return new OpenAPI()
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .addServersItem(server)
+                .components(components);
+    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            ApiErrorCodeExample apiErrorCodeExample =
+                    handlerMethod.getMethodAnnotation(ApiErrorCodeExample.class);
+            if (apiErrorCodeExample != null) {
+                generateErrorCodeResponseExample(operation, apiErrorCodeExample.value());
+            }
+            return operation;
+        };
+    }
+
+    private void generateErrorCodeResponseExample(Operation operation, ErrorStatus[] errorStatuses) {
+        ApiResponses responses = operation.getResponses();
+
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders =
+                Arrays.stream(errorStatuses)
+                        .map(
+                                errorStatus -> {
+                                    Reason errorReason = errorStatus.getReason();
+                                    return ExampleHolder.builder()
+                                            .holder(
+                                                    getSwaggerExample(
+                                                            errorReason.getMessage(),
+                                                            errorReason))
+                                            .code(errorReason.getCode())
+                                            .name(errorReason.getCode().toString())
+                                            .build();
+                                })
+                        .collect(groupingBy(ExampleHolder::getCode));
+
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    private Example getSwaggerExample(String value, Reason errorReason) {
+        ApiResponseDto<Object> responseDto = ApiResponseDto.onFailure(errorReason.getCode(), value, null);
+        Example example = new Example();
+        example.description(value);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            String jsonResponseDto = objectMapper.writeValueAsString(responseDto);
+            example.setValue(jsonResponseDto);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        return example;
+    }
+
+    private void addExamplesToResponses(
+            ApiResponses responses, Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach(
+                (status, v) -> {
+                    Content content = new Content();
+                    MediaType mediaType = new MediaType();
+                    ApiResponse apiResponse = new ApiResponse();
+                    v.forEach(
+                            exampleHolder -> mediaType.addExamples(
+                                    exampleHolder.getName(), exampleHolder.getHolder()));
+                    content.addMediaType("application/json", mediaType);
+                    apiResponse.setContent(content);
+                    responses.addApiResponse(status.toString(), apiResponse);
+                });
+    }
+}

--- a/src/main/java/com/rockoon/presentation/payload/holder/ExampleHolder.java
+++ b/src/main/java/com/rockoon/presentation/payload/holder/ExampleHolder.java
@@ -1,0 +1,13 @@
+package com.rockoon.presentation.payload.holder;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+    private Example holder;
+    private String name;
+    private int code;
+}

--- a/src/main/java/com/rockoon/security/config/SecurityConfig.java
+++ b/src/main/java/com/rockoon/security/config/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig {
                             .requestMatchers("/ws/**", "/subscribe/**", "/publish/**").permitAll()
                             .requestMatchers("/", "/.well-known/**", "/css/**", "/*.ico", "/error", "/images/**").permitAll()
                             .requestMatchers(permitAllRequest()).permitAll()
+                            .requestMatchers(additionalSwaggerRequests()).permitAll()
                             .anyRequest().authenticated();
 //                            .requestMatchers(authorizationAdmin()).hasRole("ADMIN")
 //                            .requestMatchers(authorizationDormant()).hasRole("DORMANT")
@@ -86,6 +87,19 @@ public class SecurityConfig {
                 antMatcher(HttpMethod.POST, "/api/members"),
                 antMatcher(HttpMethod.GET,"/api/members/**"),
                 antMatcher(HttpMethod.GET, "/api/tokens/login")
+        );
+        return requestMatchers.toArray(RequestMatcher[]::new);
+    }
+    private RequestMatcher[] additionalSwaggerRequests() {
+        List<RequestMatcher> requestMatchers = List.of(
+                antMatcher("/swagger-ui/**"),
+                antMatcher("/swagger-ui"),
+                antMatcher("/swagger-ui.html"),
+                antMatcher("/swagger/**"),
+                antMatcher("/swagger-resources/**"),
+                antMatcher("/v3/api-docs/**"),
+                antMatcher("/profile")
+
         );
         return requestMatchers.toArray(RequestMatcher[]::new);
     }

--- a/src/main/java/com/rockoon/security/config/SecurityConfig.java
+++ b/src/main/java/com/rockoon/security/config/SecurityConfig.java
@@ -86,6 +86,7 @@ public class SecurityConfig {
                 antMatcher(HttpMethod.GET, "/"),
                 antMatcher(HttpMethod.POST, "/api/members"),
                 antMatcher(HttpMethod.GET,"/api/members/**"),
+                antMatcher(HttpMethod.GET, "/api/promotions/**"),
                 antMatcher(HttpMethod.GET, "/api/tokens/login")
         );
         return requestMatchers.toArray(RequestMatcher[]::new);

--- a/src/main/java/com/rockoon/security/controller/TokenApiController.java
+++ b/src/main/java/com/rockoon/security/controller/TokenApiController.java
@@ -1,20 +1,32 @@
 package com.rockoon.security.controller;
 
+import com.rockoon.global.annotation.api.ApiErrorCodeExample;
+import com.rockoon.presentation.payload.code.ErrorStatus;
 import com.rockoon.presentation.payload.dto.ApiResponseDto;
 import com.rockoon.security.jwt.dto.JwtToken;
 import com.rockoon.security.jwt.service.TokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Token API", description = "토큰 API")
+@ApiResponse(responseCode = "2000", description = "성공")
 @RequiredArgsConstructor
 @RequestMapping("/api/tokens")
 @RestController
 public class TokenApiController {
     private final TokenService tokenService;
 
+    @Operation(summary = "로그인(토큰 생성)", description = "카카오이메일을 통해 로그인합니다.")
+    @ApiErrorCodeExample({
+            ErrorStatus._INTERNAL_SERVER_ERROR,
+            ErrorStatus.MEMBER_NOT_FOUND
+    })
     @GetMapping("/login")
     public ApiResponseDto<JwtToken> login(@RequestParam String kakaoEmail) {
         return ApiResponseDto.onSuccess(tokenService.login(kakaoEmail));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,12 @@ spring:
     host: localhost
     port: 6379
 
+springdoc:
+  swagger-ui:
+    tags-sorter: alpha
+    operations-sorter: method
+  use-fqn: true
+
 app:
   jwt:
     secret: ${JWT_SECRET_KEY}       # intellij 상단 run -> edit config -> enviromnent variable에 추가


### PR DESCRIPTION
## 🔎 Description
> setting swagger for cooperation with front
1. swagger config 작성
2. controller swagger setting
3. authuser hidden
4. yml파일 세팅(오름차순)

### localhost:8080/swagger-ui/index.html#/
서버 러닝 후 해당 path를 검색하면 swagger page를 확인할 수 있다.

<img width="1511" alt="스크린샷 2024-05-28 오후 5 46 15" src="https://github.com/Play-barcode/play-barcode.back/assets/69452755/e3ab85b7-e064-41b2-bfc2-09e7d8452aa8">
<img width="834" alt="스크린샷 2024-05-28 오후 5 46 37" src="https://github.com/Play-barcode/play-barcode.back/assets/69452755/b8315dd2-91d3-4088-94ca-68de4ac7033a">
api 우측 자물쇠를 클릭하면 해당 페이지를 조회할 수 있다. 여기에 [액세스 토큰]을 넣으면 인증 api 사용이 가능하다.

## 🔗 Related Issue
- https://github.com/Play-barcode/play-barcode.back/issues/24

## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [ ] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
