### PR TITLE
[Refactor/swagger/#60] add error status in swagger

### DIFF
--- a/src/main/java/com/bandit/domain/board/controller/PromotionApiController.java
+++ b/src/main/java/com/bandit/domain/board/controller/PromotionApiController.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.bandit.domain.board.dto.promotion.PromotionResponse.PromotionDetailDto;
+import static com.bandit.global.annotation.api.PredefinedErrorStatus.AUTH;
 
 @Tag(name = "Promotion API", description = "프로모션 API")
 @ApiResponse(responseCode = "2000", description = "성공")
@@ -36,12 +37,7 @@ public class PromotionApiController {
     private final PromotionQueryService promotionQueryService;
 
     @Operation(summary = "프로모션 작성 🔑", description = "로그인한 회원이 프로모션(홍보글)을 작성합니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND
-    })
+    @ApiErrorCodeExample(status = AUTH)
     @PostMapping
     public ApiResponseDto<Long> createPromotion(@AuthUser Member member,
                                                 @RequestBody PromotionRequest promotionRequest) {
@@ -55,20 +51,19 @@ public class PromotionApiController {
 
     @Operation(summary = "프로모션 수정 🔑", description = "로그인한 회원이 프로모션(홍보글)을 작성했던 글을 수정합니다." +
             "권한은 작성자에게만 있습니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND,
+    @ApiErrorCodeExample(value = {
             ErrorStatus.PROMOTION_NOT_FOUND,
-            ErrorStatus.PROMOTION_ONLY_CAN_BE_TOUCHED_BY_WRITER
-    })
+            ErrorStatus.PROMOTION_ONLY_CAN_BE_TOUCHED_BY_WRITER,
+            ErrorStatus.TICKET_NOT_FOUND,
+            ErrorStatus.IMAGE_REQUEST_IS_EMPTY
+    }, status = AUTH)
     @PutMapping("/{promotionId}")
     public ApiResponseDto<Long> modifyPromotion(@AuthUser Member member,
                                                 @PathVariable Long promotionId,
                                                 @RequestBody PromotionRequest promotionRequest) {
         List<String> imageList = promotionRequest.getImageList().stream()
                 .map(ImageUtil::removePrefix)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
         promotionRequest.setImageList(imageList);
         return ApiResponseDto.onSuccess(promotionCommandService.modifyPromotion(member, promotionId, promotionRequest));
@@ -76,7 +71,6 @@ public class PromotionApiController {
 
     @Operation(summary = "프로모션 조회", description = "프로모션의 PK를 통해 글을 조회합니다.")
     @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
             ErrorStatus.PROMOTION_NOT_FOUND
     })
     @GetMapping("/{promotionId}")
@@ -90,10 +84,7 @@ public class PromotionApiController {
 
     @Operation(summary = "프로모션 페이징 조회", description = "프로모션의 리스트를 페이징을 통해 조회합니다." +
             "한페이지당 사이즈는 10개입니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus.PROMOTION_NOT_FOUND
-    })
+    @ApiErrorCodeExample
     @GetMapping
     public ApiResponseDto<PromotionListDto> getPromotionList(@RequestParam(defaultValue = "0") int currentPage) {
         Pageable pageable = PageRequest.of(currentPage, PageUtil.PROMOTION_SIZE);
@@ -105,10 +96,7 @@ public class PromotionApiController {
     }
     @Operation(summary = "프로모션 페이징 검색", description = "프로모션을 키워드를 통해 조회합니다." +
             "한페이지당 사이즈는 10개입니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus.PROMOTION_NOT_FOUND
-    })
+    @ApiErrorCodeExample
     @GetMapping("/search")
     public ApiResponseDto<PromotionListDto> searchPromotionList(
             @RequestParam(defaultValue = "0") int currentPage,
@@ -120,12 +108,12 @@ public class PromotionApiController {
                 )
         );
     }
+
     @Operation(summary = "마이 프로모션 페이징 조회 🔑", description = "사용자가 소유하는 프로모션을 페이징 조회합니다." +
             "한페이지당 사이즈는 10개입니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
+    @ApiErrorCodeExample(value = {
             ErrorStatus.PROMOTION_NOT_FOUND
-    })
+    }, status = AUTH)
     @GetMapping("/my")
     public ApiResponseDto<PromotionListDto> getMyPromotionList(
             @AuthUser Member member,
@@ -141,14 +129,11 @@ public class PromotionApiController {
 
     @Operation(summary = "프로모션 삭제 🔑", description = "로그인한 회원이 프로모션(홍보글)을 작성했던 글을 삭제합니다." +
             "권한은 작성자에게만 있습니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND,
+    @ApiErrorCodeExample(value = {
             ErrorStatus.PROMOTION_NOT_FOUND,
-            ErrorStatus.PROMOTION_ONLY_CAN_BE_TOUCHED_BY_WRITER
-    })
+            ErrorStatus.PROMOTION_ONLY_CAN_BE_TOUCHED_BY_WRITER,
+            ErrorStatus.IMAGE_REQUEST_IS_EMPTY
+    }, status = AUTH)
     @DeleteMapping("/{promotionId}")
     public ApiResponseDto<Boolean> deletePromotion(@AuthUser Member member,
                                                    @PathVariable Long promotionId) {

--- a/src/main/java/com/bandit/domain/comment/controller/CommentApiController.java
+++ b/src/main/java/com/bandit/domain/comment/controller/CommentApiController.java
@@ -19,6 +19,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
+import static com.bandit.global.annotation.api.PredefinedErrorStatus.AUTH;
+
 @Tag(name = "Comment API", description = "댓글 API")
 @ApiResponse(responseCode = "2000", description = "성공")
 @RequestMapping("/api/comments")
@@ -29,12 +31,9 @@ public class CommentApiController {
     private final CommentQueryService commentQueryService;
 
     @Operation(summary = "댓글 작성 🔑", description = "로그인한 회원이 프로모션(홍보글)에 댓글을 작성합니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND
-    })
+    @ApiErrorCodeExample(value = {
+            ErrorStatus.PROMOTION_NOT_FOUND
+    }, status = AUTH)
     @PostMapping("/{promotionId}")
     public ApiResponseDto<Long> createComment(@AuthUser Member member,
                                               @PathVariable Long promotionId,
@@ -42,22 +41,18 @@ public class CommentApiController {
         return ApiResponseDto.onSuccess(commentCommandService.createComment(member, promotionId, commentRequest));
     }
     @Operation(summary = "댓글 삭제 🔑", description = "작성자가 등록한 댓글을 삭제합니다")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND
-    })
+    @ApiErrorCodeExample(value = {
+            ErrorStatus.COMMENT_NOT_FOUND,
+            ErrorStatus.COMMENT_CAN_BE_ONLY_TOUCHED_BY_WRITER
+    }, status = AUTH)
     @DeleteMapping("/{commentId}")
     public ApiResponseDto<Boolean> removeComment(@AuthUser Member member,
-                                              @PathVariable Long commentId) {
+                                                 @PathVariable Long commentId) {
         commentCommandService.removeComment(member, commentId);
         return ApiResponseDto.onSuccess(true);
     }
     @Operation(summary = "댓글 조회(페이징)", description = "프로모션에 등록된 댓글들을 조회합니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR
-    })
+    @ApiErrorCodeExample
     @GetMapping("/{promotionId}")
     public ApiResponseDto<CommentListDto> removeComment(@PathVariable Long promotionId,
                                                         @RequestParam(defaultValue = "0") int currentPage) {

--- a/src/main/java/com/bandit/domain/image/controller/ImageApiController.java
+++ b/src/main/java/com/bandit/domain/image/controller/ImageApiController.java
@@ -29,8 +29,7 @@ public class ImageApiController {
 
     @Operation(summary = "이미지 요청 🔑", description = "이미지 파일들을 로컬 환경에서 불러와 s3에 업로드합니다." +
             "s3저장된 이미지 url을 반환합니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
+    @ApiErrorCodeExample(value = {
             ErrorStatus.IMAGE_REQUEST_IS_EMPTY
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/bandit/domain/like/controller/LikeMusicApiController.java
+++ b/src/main/java/com/bandit/domain/like/controller/LikeMusicApiController.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import static com.bandit.global.annotation.api.PredefinedErrorStatus.AUTH;
+
 @Tag(name = "LikeMusic API", description = "노래 좋아요 API")
 @ApiResponse(responseCode = "2000", description = "성공")
 @RequestMapping("/api/likes/music")
@@ -23,12 +25,10 @@ public class LikeMusicApiController {
     private final LikeMusicQueryService likeMusicQueryService;
 
     @Operation(summary = "셑리스트 좋아요 🔑", description = "로그인한 회원이 프로모션 내 셑리스트에 좋아요를 누릅니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND
-    })
+    @ApiErrorCodeExample(value = {
+            ErrorStatus.PROMOTION_MUSIC_NOT_FOUND,
+            ErrorStatus.LIKE_ALREADY_EXIST
+    }, status = AUTH)
     @PostMapping("/{musicId}")
     public ApiResponseDto<Long> likeSetList(@AuthUser Member member,
                                             @PathVariable Long musicId) {
@@ -37,13 +37,9 @@ public class LikeMusicApiController {
     }
 
     @Operation(summary = "셑리스트 좋아요 취소 🔑", description = "로그인한 회원이 프로모션 내 셑리스트의 좋아요를 취소합니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND,
+    @ApiErrorCodeExample(value = {
             ErrorStatus.LIKE_NOT_FOUND
-    })
+    }, status = AUTH)
     @DeleteMapping("/{musicId}")
     public ApiResponseDto<Boolean> unlikeSetList(@AuthUser Member member,
                                                  @PathVariable Long musicId) {
@@ -52,13 +48,7 @@ public class LikeMusicApiController {
     }
 
     @Operation(summary = "셑리스트 좋아요 확인 🔑", description = "로그인한 회원이 좋아요한 프로모션 내 셑리스트를 확인합니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND,
-            ErrorStatus.LIKE_NOT_FOUND
-    })
+    @ApiErrorCodeExample(status = AUTH)
     @GetMapping("/{musicId}")
     public ApiResponseDto<Boolean> checkIsLiked(@AuthUser Member member,
                                                  @PathVariable Long musicId) {
@@ -66,13 +56,7 @@ public class LikeMusicApiController {
     }
 
     @Operation(summary = "셑리스트 좋아요 확인", description = "셑리스트의 좋아요 개수를 확인합니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND,
-            ErrorStatus.LIKE_NOT_FOUND
-    })
+    @ApiErrorCodeExample
     @GetMapping("/{musicId}/count")
     public ApiResponseDto<Long> countLike(@PathVariable Long musicId) {
         return ApiResponseDto.onSuccess(likeMusicQueryService.countLike(musicId));

--- a/src/main/java/com/bandit/domain/like/controller/LikePromotionApiController.java
+++ b/src/main/java/com/bandit/domain/like/controller/LikePromotionApiController.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import static com.bandit.global.annotation.api.PredefinedErrorStatus.AUTH;
+
 @Tag(name = "LikePromotion API", description = "프로모션 좋아요 API")
 @ApiResponse(responseCode = "2000", description = "성공")
 @RequestMapping("/api/likes/promotion")
@@ -23,12 +25,10 @@ public class LikePromotionApiController {
     private final LikePromotionCommandService likePromotionCommandService;
 
     @Operation(summary = "프로모션 좋아요 🔑", description = "로그인한 회원이 프로모션 좋아요를 누릅니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND
-    })
+    @ApiErrorCodeExample(value = {
+            ErrorStatus.PROMOTION_NOT_FOUND,
+            ErrorStatus.LIKE_ALREADY_EXIST
+    }, status = AUTH)
     @PostMapping("/{promotionId}")
     public ApiResponseDto<Long> likeSetList(@AuthUser Member member,
                                             @PathVariable Long promotionId) {
@@ -37,13 +37,9 @@ public class LikePromotionApiController {
     }
 
     @Operation(summary = "프로모션 좋아요 취소 🔑", description = "로그인한 회원이 프로모션의 좋아요를 취소합니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND,
+    @ApiErrorCodeExample(value = {
             ErrorStatus.LIKE_NOT_FOUND
-    })
+    }, status = AUTH)
     @DeleteMapping("/{promotionId}")
     public ApiResponseDto<Boolean> unlikeSetList(@AuthUser Member member,
                                                  @PathVariable Long promotionId) {
@@ -52,13 +48,7 @@ public class LikePromotionApiController {
     }
 
     @Operation(summary = "프로모션 좋아요 확인 🔑", description = "로그인한 회원이 프로모션을 좋아요 했는지 확인합니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND,
-            ErrorStatus.LIKE_NOT_FOUND
-    })
+    @ApiErrorCodeExample(status = AUTH)
     @GetMapping("/{promotionId}")
     public ApiResponseDto<Boolean> checkIsLiked(@AuthUser Member member,
                                                 @PathVariable Long promotionId) {
@@ -66,13 +56,7 @@ public class LikePromotionApiController {
     }
 
     @Operation(summary = "프로모션 좋아요 개수 확인", description = "프로모션 좋아요 개수를 확인합니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND,
-            ErrorStatus.LIKE_NOT_FOUND
-    })
+    @ApiErrorCodeExample
     @GetMapping("/{promotionId}/count")
     public ApiResponseDto<Long> countLike(@PathVariable Long promotionId) {
         return ApiResponseDto.onSuccess(likePromotionQueryService.countLike(promotionId));

--- a/src/main/java/com/bandit/domain/like/service/like_music/LikeMusicCommandServiceImpl.java
+++ b/src/main/java/com/bandit/domain/like/service/like_music/LikeMusicCommandServiceImpl.java
@@ -30,7 +30,6 @@ public class LikeMusicCommandServiceImpl implements LikeMusicCommandService {
 
     @Override
     public void unlikeMusic(Long musicId, Member member) {
-        validateNotFound(musicId, member);
         LikeMusic likeMusic = likeMusicRepository.findByMusicIdAndMember(musicId, member)
                 .orElseThrow(() -> new LikeHandler(ErrorStatus.LIKE_NOT_FOUND));
         likeMusicRepository.delete(likeMusic);
@@ -39,12 +38,6 @@ public class LikeMusicCommandServiceImpl implements LikeMusicCommandService {
     private void validateAlreadyExist(Long musicId, Member member) {
         if (likeMusicRepository.existsByMusicIdAndMember(musicId, member)) {
             throw new LikeHandler(ErrorStatus.LIKE_ALREADY_EXIST);
-        }
-    }
-
-    private void validateNotFound(Long musicId, Member member) {
-        if (!likeMusicRepository.existsByMusicIdAndMember(musicId, member)) {
-            throw new LikeHandler(ErrorStatus.LIKE_NOT_FOUND);
         }
     }
 }

--- a/src/main/java/com/bandit/domain/member/controller/MemberApiController.java
+++ b/src/main/java/com/bandit/domain/member/controller/MemberApiController.java
@@ -23,6 +23,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static com.bandit.global.annotation.api.PredefinedErrorStatus.AUTH;
+
 @Tag(name = "Member API", description = "회원 API")
 @ApiResponse(responseCode = "2000", description = "성공")
 @RequestMapping("/api/members")
@@ -36,9 +38,7 @@ public class MemberApiController {
 
     @Operation(summary = "회원가입", description = "회원정보를 통해 서버 내 회원가입을 진행합니다. " +
             "kakaoEmail, profileImg, nickname, name의 정보를 받습니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR
-    })
+    @ApiErrorCodeExample
     @PostMapping        //TODO 나중에 지워도 됨
     public ApiResponseDto<Long> registerMember(@RequestBody MemberRegisterDto memberRegisterDto) {
         memberRegisterDto.setProfileImg(ImageUtil.removePrefix(memberRegisterDto.getProfileImg()));
@@ -47,12 +47,7 @@ public class MemberApiController {
 
     @Operation(summary = "회원 정보 수정 🔑", description = "로그인한 회원의 정보를 수정합니다. " +
             "profileImg, nickname, name을 변경할 수 있습니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND
-    })
+    @ApiErrorCodeExample(status = AUTH)
     @PutMapping
     public ApiResponseDto<Long> modifyMemberInfo(@AuthUser Member member,
                                                  @RequestBody MemberModifyDto memberModifyDto) {
@@ -62,7 +57,6 @@ public class MemberApiController {
 
     @Operation(summary = "회원 정보 조회", description = "PK를 통해 사용자의 정보를 조회합니다.")
     @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
             ErrorStatus.MEMBER_NOT_FOUND
     })
     @GetMapping("/{memberId}")
@@ -74,21 +68,19 @@ public class MemberApiController {
         );
     }
     @Operation(summary = "회원 정보 조회 🔑", description = "액세스토큰을 통해 사용자의 정보를 조회합니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
-            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
-            ErrorStatus._ASSIGNABLE_PARAMETER,
-            ErrorStatus.MEMBER_NOT_FOUND
-    })
+    @ApiErrorCodeExample(status = AUTH)
     @GetMapping
     public ApiResponseDto<MemberResponse> getMemberInfo(@AuthUser Member member) {
         return ApiResponseDto.onSuccess(MemberConverter.toResponse(member));
     }
 
     @Operation(summary = "회원 삭제 🔑", description = "액세스 토큰을 통해 사용자에 관한 정보를 모두 지웁니다.")
-    @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR
-    })
+    @ApiErrorCodeExample(value = {
+            ErrorStatus.PROMOTION_NOT_FOUND,
+            ErrorStatus.PROMOTION_ONLY_CAN_BE_TOUCHED_BY_WRITER,
+            ErrorStatus.IMAGE_REQUEST_IS_EMPTY
+
+    }, status = AUTH)
     @DeleteMapping
     public ApiResponseDto<Boolean> removeMember(@AuthUser Member member) {
         List<Promotion> promotionIdList = promotionQueryService.getPromotionIdByMember(member);

--- a/src/main/java/com/bandit/domain/ticket/controller/GuestApiController.java
+++ b/src/main/java/com/bandit/domain/ticket/controller/GuestApiController.java
@@ -24,6 +24,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static com.bandit.global.annotation.api.PredefinedErrorStatus.AUTH;
+
 @Tag(name = "Guest API", description = "게스트 관련 API")
 @ApiResponse(responseCode = "2000", description = "성공")
 @RestController
@@ -35,8 +37,9 @@ public class GuestApiController {
     private final GuestQueryService guestQueryService;
 
     @Operation(summary = "게스트 생성 🔑", description = "프로모션 ID와 멤버 정보, 이름을 받아 새로운 게스트를 생성합니다.")
-    @ApiErrorCodeExample(
-            {ErrorStatus._INTERNAL_SERVER_ERROR})
+    @ApiErrorCodeExample(value = {
+            ErrorStatus.PROMOTION_NOT_FOUND
+    }, status = AUTH)
     @PostMapping("/{promotionId}")
     public ApiResponseDto<Long> createGuest(
             @PathVariable Long promotionId,
@@ -46,8 +49,10 @@ public class GuestApiController {
         return ApiResponseDto.onSuccess(guestId);
     }
     @Operation(summary = "게스트 입장 🔑", description = "프로모션의 티켓 uuid를 통해 게스트를 입장 처리해줍니다.")
-    @ApiErrorCodeExample(
-            {ErrorStatus._INTERNAL_SERVER_ERROR})
+    @ApiErrorCodeExample(value = {
+            ErrorStatus.TICKET_NOT_FOUND,
+            ErrorStatus.GUEST_NOT_FOUND
+    }, status = AUTH)
     @PostMapping("/entrance")
     public ApiResponseDto<Boolean> entranceGuest(@RequestParam String uuid,
                                                  @AuthUser Member member) {
@@ -56,9 +61,11 @@ public class GuestApiController {
     }
 
     @Operation(summary = "게스트 수정 🔑", description = "게스트 ID와 게스트 정보를 받아 기존 게스트 정보를 수정합니다.")
-    @ApiErrorCodeExample(
-            {ErrorStatus._INTERNAL_SERVER_ERROR})
-    @PutMapping("/{guestId}")
+    @ApiErrorCodeExample(value = {
+            ErrorStatus.GUEST_NOT_FOUND,
+            ErrorStatus.GUEST_ONLY_CAN_BE_TOUCHED_BY_CREATOR
+    }, status = AUTH)
+    @PutMapping("/{guestId}")       //TODO remove this api(not use)
     public ApiResponseDto<Long> updateGuest(
             @PathVariable Long guestId,
             @AuthUser Member member,
@@ -67,8 +74,10 @@ public class GuestApiController {
     }
 
     @Operation(summary = "게스트 삭제 🔑", description = "게스트 ID를 받아 해당 게스트를 삭제합니다.")
-    @ApiErrorCodeExample(
-            {ErrorStatus._INTERNAL_SERVER_ERROR})
+    @ApiErrorCodeExample(value = {
+            ErrorStatus.GUEST_NOT_FOUND,
+            ErrorStatus.GUEST_ONLY_CAN_BE_TOUCHED_BY_CREATOR
+    }, status = AUTH)
     @DeleteMapping("/{guestId}")
     public ApiResponseDto<Boolean> deleteGuest(@PathVariable Long guestId,
                                             @AuthUser Member member) {
@@ -78,8 +87,10 @@ public class GuestApiController {
 
 
     @Operation(summary = "게스트 조회 🔑", description = "게스트 ID를 받아 해당 게스트 정보를 조회합니다.")
-    @ApiErrorCodeExample(
-            {ErrorStatus._INTERNAL_SERVER_ERROR})
+    @ApiErrorCodeExample(value = {
+            ErrorStatus.GUEST_NOT_FOUND,
+            ErrorStatus.GUEST_ONLY_CAN_BE_TOUCHED_BY_CREATOR
+    }, status = AUTH)
     @GetMapping("/{guestId}")
     public ApiResponseDto<GuestResponse.GuestViewDto> getGuestById(@PathVariable Long guestId,
                                                                    @AuthUser Member member) {
@@ -87,8 +98,10 @@ public class GuestApiController {
     }
 
     @Operation(summary = "프로모션 ID로 게스트 조회 🔑", description = "프로모션 ID를 받아 해당 프로모션에 속한 모든 게스트 정보를 조회합니다.")
-    @ApiErrorCodeExample(
-            {ErrorStatus._INTERNAL_SERVER_ERROR})
+    @ApiErrorCodeExample(value = {
+            ErrorStatus.PROMOTION_NOT_FOUND,
+            ErrorStatus.GUEST_ONLY_CAN_BE_TOUCHED_BY_CREATOR
+    }, status = AUTH)
     @GetMapping("/promotions/{promotionId}")
     public ApiResponseDto<GuestListDto> getGuestsByPromotionId(@PathVariable Long promotionId,
                                                                @AuthUser Member member) {
@@ -97,8 +110,10 @@ public class GuestApiController {
     }
 
     @Operation(summary = "프로모션 ID로 게스트 페이징 조회 🔑", description = "프로모션 ID를 받아 해당 프로모션에 속한 게스트 정보를 페이지별로 조회합니다.")
-    @ApiErrorCodeExample(
-            {ErrorStatus._INTERNAL_SERVER_ERROR})
+    @ApiErrorCodeExample(value = {
+            ErrorStatus.PROMOTION_NOT_FOUND,
+            ErrorStatus.GUEST_ONLY_CAN_BE_TOUCHED_BY_CREATOR
+    }, status = AUTH)
     @GetMapping("/promotions/{promotionId}/page")
     public ApiResponseDto<GuestListDto> getGuestsByPromotionIdPaged(
             @PathVariable Long promotionId,

--- a/src/main/java/com/bandit/domain/ticket/controller/TicketApiController.java
+++ b/src/main/java/com/bandit/domain/ticket/controller/TicketApiController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.bandit.global.annotation.api.PredefinedErrorStatus.AUTH;
+
 @Tag(name = "Ticket API", description = "티켓 관련 API")
 @ApiResponse(responseCode = "2000", description = "성공")
 @RestController
@@ -28,7 +30,10 @@ public class TicketApiController {
     private final TicketQueryService ticketQueryService;
 
     @Operation(summary = "티켓 조회 🔑", description = "티켓 ID를 받아 해당 티켓의 정보를 조회합니다.")
-    @ApiErrorCodeExample({ErrorStatus._INTERNAL_SERVER_ERROR})
+    @ApiErrorCodeExample(value = {
+            ErrorStatus.TICKET_NOT_FOUND,
+            ErrorStatus.TICKET_ONLY_CAN_BE_OPENED_BY_MANAGERS
+    }, status = AUTH)
     @GetMapping("/promotions/{promotionId}")
     public ApiResponseDto<TicketResponse> getTicketById(@PathVariable Long promotionId,
                                                         @AuthUser Member member) {

--- a/src/main/java/com/bandit/global/annotation/api/ApiErrorCodeExample.java
+++ b/src/main/java/com/bandit/global/annotation/api/ApiErrorCodeExample.java
@@ -7,8 +7,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import static com.bandit.global.annotation.api.PredefinedErrorStatus.DEFAULT;
+
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiErrorCodeExample {
-    ErrorStatus[] value();
+    ErrorStatus[] value() default {ErrorStatus._INTERNAL_SERVER_ERROR};
+
+    PredefinedErrorStatus status() default DEFAULT;
 }

--- a/src/main/java/com/bandit/global/annotation/api/PredefinedErrorStatus.java
+++ b/src/main/java/com/bandit/global/annotation/api/PredefinedErrorStatus.java
@@ -1,0 +1,25 @@
+package com.bandit.global.annotation.api;
+
+import com.bandit.presentation.payload.code.ErrorStatus;
+
+import java.util.List;
+
+public enum PredefinedErrorStatus {
+    DEFAULT(List.of(ErrorStatus._INTERNAL_SERVER_ERROR)),
+    AUTH(List.of(
+            ErrorStatus._INTERNAL_SERVER_ERROR,
+            ErrorStatus._UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR,
+            ErrorStatus._ASSIGNABLE_PARAMETER,
+            ErrorStatus.MEMBER_NOT_FOUND
+    ));
+
+    private final List<ErrorStatus> errorStatuses;
+
+    PredefinedErrorStatus(List<ErrorStatus> errorStatuses) {
+        this.errorStatuses = errorStatuses;
+    }
+
+    public List<ErrorStatus> getErrorStatuses() {
+        return errorStatuses;
+    }
+}

--- a/src/main/java/com/bandit/security/controller/TokenApiController.java
+++ b/src/main/java/com/bandit/security/controller/TokenApiController.java
@@ -20,7 +20,6 @@ public class TokenApiController {
     private final TokenService tokenService;
     @Operation(summary = "로그인(토큰 생성)", description = "카카오이메일을 통해 로그인합니다.")
     @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
             ErrorStatus.MEMBER_NOT_FOUND
     })
     @GetMapping("/login")       //test용
@@ -30,7 +29,6 @@ public class TokenApiController {
 
     @Operation(summary = "토큰 재발행", description = "리프레시 토큰을 통해 토큰을 재발행 받습니다.")
     @ApiErrorCodeExample({
-            ErrorStatus._INTERNAL_SERVER_ERROR,
             ErrorStatus.MEMBER_NOT_FOUND
     })
     @PostMapping("/reissue")


### PR DESCRIPTION
## 🔎 Description
> add error status in swagger
1. predefinederrorstatus enum 생성
2. predefinederrorstatus로 defaut, auth에서 중복되는 에러스테이터스 생략 처리(SwaggerConfig)
3. 모든 api에 적용


## 🔗 Related Issue
- https://github.com/b-and-it/bandit.back/issues/60

## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [x] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
