### PR TITLE
[Refactor/#97]  unify like data when getting promotion data

### DIFF
--- a/src/main/java/com/bandit/domain/board/controller/PromotionApiV2Controller.java
+++ b/src/main/java/com/bandit/domain/board/controller/PromotionApiV2Controller.java
@@ -1,7 +1,6 @@
 package com.bandit.domain.board.controller;
 
 import com.bandit.domain.board.converter.PromotionConverter;
-import com.bandit.domain.board.dto.promotion.PromotionResponse;
 import com.bandit.domain.board.dto.promotion.PromotionResponse.PromotionDetailDto;
 import com.bandit.domain.board.dto.promotion.PromotionResponse.PromotionListDto;
 import com.bandit.domain.board.service.promotion.PromotionCommandService;
@@ -19,9 +18,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Promotion API", description = "프로모션 API")
+@Tag(name = "Promotion API V2", description = "프로모션 API V2")
 @ApiResponse(responseCode = "2000", description = "성공")
-@RequestMapping("/api/promotions/v2")
+@RequestMapping("/api/v2/promotions")
 @RequiredArgsConstructor
 @RestController
 public class PromotionApiV2Controller {
@@ -43,8 +42,8 @@ public class PromotionApiV2Controller {
     @ApiErrorCodeExample({
             ErrorStatus.PROMOTION_NOT_FOUND
     })
-    @GetMapping("/{promotionId}")
-    public ApiResponseDto<PromotionDetailDto> getPromotionById(@PathVariable Long promotionId) {
+    @GetMapping("/{promotionId}/auth")
+    public ApiResponseDto<PromotionDetailDto> getPromotionById_auth(@PathVariable Long promotionId) {
         PromotionDetailDto detailDto = PromotionConverter.toDetailDto(promotionQueryService.getPromotionById(promotionId));
         likeMusicQueryService.countLike(detailDto);
         return ApiResponseDto.onSuccess(detailDto);
@@ -65,8 +64,8 @@ public class PromotionApiV2Controller {
     @Operation(summary = "프로모션 페이징 조회(인증🔑)", description = "프로모션의 리스트를 페이징을 통해 조회합니다." +
             "한페이지당 사이즈는 10개입니다.")
     @ApiErrorCodeExample
-    @GetMapping
-    public ApiResponseDto<PromotionListDto> getPromotionList(@RequestParam(defaultValue = "0") int currentPage) {
+    @GetMapping("/auth")
+    public ApiResponseDto<PromotionListDto> getPromotionList_auth(@RequestParam(defaultValue = "0") int currentPage) {
         Pageable pageable = PageRequest.of(currentPage, PageUtil.PROMOTION_SIZE);
         return ApiResponseDto.onSuccess(
                 PromotionConverter.toListDto(

--- a/src/main/java/com/bandit/domain/board/controller/PromotionApiV2Controller.java
+++ b/src/main/java/com/bandit/domain/board/controller/PromotionApiV2Controller.java
@@ -99,6 +99,56 @@ public class PromotionApiV2Controller {
         return ApiResponseDto.onSuccess(listDto);
     }
 
+    @Operation(summary = "프로모션 페이징 검색(비인증)", description = "프로모션을 키워드를 통해 조회합니다." +
+            "한페이지당 사이즈는 10개입니다.")
+    @ApiErrorCodeExample
+    @GetMapping("/search")
+    public ApiResponseDto<PromotionListDto> searchPromotionList(
+            @RequestParam(defaultValue = "0") int currentPage,
+            @RequestParam(required = false) String keyword) {
+        Pageable pageable = PageRequest.of(currentPage, PageUtil.PROMOTION_SIZE);
+        PromotionListDto listDto = PromotionConverter.toListDto(
+                promotionQueryService.searchPaginationPromotion(keyword, pageable)
+        );
+        listDto.getPromotionList().forEach(dto -> PromotionConverter.setPromotionLikeInDto(dto,
+                likePromotionQueryService.countLike(dto.getPromotionId()),
+                false));
+        return ApiResponseDto.onSuccess(listDto);
+    }
+    @Operation(summary = "프로모션 페이징 검색(인증🔑)", description = "프로모션을 키워드를 통해 조회합니다." +
+            "한페이지당 사이즈는 10개입니다.")
+    @ApiErrorCodeExample
+    @GetMapping("/search/auth")
+    public ApiResponseDto<PromotionListDto> searchPromotionList_auth(
+            @AuthUser Member member,
+            @RequestParam(defaultValue = "0") int currentPage,
+            @RequestParam(required = false) String keyword) {
+        Pageable pageable = PageRequest.of(currentPage, PageUtil.PROMOTION_SIZE);
+        PromotionListDto listDto = PromotionConverter.toListDto(
+                promotionQueryService.searchPaginationPromotion(keyword, pageable)
+        );
+        listDto.getPromotionList().forEach(dto -> PromotionConverter.setPromotionLikeInDto(dto,
+                likePromotionQueryService.countLike(dto.getPromotionId()),
+                likePromotionQueryService.isLiked(dto.getPromotionId(), member)));
+        return ApiResponseDto.onSuccess(listDto);
+    }
 
-
+    @Operation(summary = "마이 프로모션 페이징 조회 🔑", description = "사용자가 소유하는 프로모션을 페이징 조회합니다." +
+            "한페이지당 사이즈는 10개입니다.")
+    @ApiErrorCodeExample(value = {
+            ErrorStatus.PROMOTION_NOT_FOUND
+    }, status = AUTH)
+    @GetMapping("/my")
+    public ApiResponseDto<PromotionListDto> getMyPromotionList(
+            @AuthUser Member member,
+            @RequestParam(defaultValue = "0") int currentPage) {
+        Pageable pageable = PageRequest.of(currentPage, PageUtil.PROMOTION_SIZE);
+        PromotionListDto listDto = PromotionConverter.toListDto(
+                promotionQueryService.getMyPaginationPromotion(member, pageable)
+        );
+        listDto.getPromotionList().forEach(dto -> PromotionConverter.setPromotionLikeInDto(dto,
+                likePromotionQueryService.countLike(dto.getPromotionId()),
+                likePromotionQueryService.isLiked(dto.getPromotionId(), member)));
+        return ApiResponseDto.onSuccess(listDto);
+    }
 }

--- a/src/main/java/com/bandit/domain/board/controller/PromotionApiV2Controller.java
+++ b/src/main/java/com/bandit/domain/board/controller/PromotionApiV2Controller.java
@@ -1,0 +1,78 @@
+package com.bandit.domain.board.controller;
+
+import com.bandit.domain.board.converter.PromotionConverter;
+import com.bandit.domain.board.dto.promotion.PromotionResponse;
+import com.bandit.domain.board.dto.promotion.PromotionResponse.PromotionDetailDto;
+import com.bandit.domain.board.dto.promotion.PromotionResponse.PromotionListDto;
+import com.bandit.domain.board.service.promotion.PromotionCommandService;
+import com.bandit.domain.board.service.promotion.PromotionQueryService;
+import com.bandit.domain.like.service.like_music.LikeMusicQueryService;
+import com.bandit.global.annotation.api.ApiErrorCodeExample;
+import com.bandit.global.util.PageUtil;
+import com.bandit.presentation.payload.code.ErrorStatus;
+import com.bandit.presentation.payload.dto.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Promotion API", description = "프로모션 API")
+@ApiResponse(responseCode = "2000", description = "성공")
+@RequestMapping("/api/promotions/v2")
+@RequiredArgsConstructor
+@RestController
+public class PromotionApiV2Controller {
+    private final PromotionCommandService promotionCommandService;
+    private final PromotionQueryService promotionQueryService;
+    private final LikeMusicQueryService likeMusicQueryService;
+
+    @Operation(summary = "프로모션 조회(비인증)", description = "로그인하지 않은 유저가 프로모션의 PK를 통해 글을 조회합니다.")
+    @ApiErrorCodeExample({
+            ErrorStatus.PROMOTION_NOT_FOUND
+    })
+    @GetMapping("/{promotionId}")
+    public ApiResponseDto<PromotionDetailDto> getPromotionById(@PathVariable Long promotionId) {
+        PromotionDetailDto detailDto = PromotionConverter.toDetailDto(promotionQueryService.getPromotionById(promotionId));
+        likeMusicQueryService.countLike(detailDto);
+        return ApiResponseDto.onSuccess(detailDto);
+    }
+    @Operation(summary = "프로모션 조회(인증🔑)", description = "로그인한 유저가 프로모션의 PK를 통해 글을 조회합니다.")
+    @ApiErrorCodeExample({
+            ErrorStatus.PROMOTION_NOT_FOUND
+    })
+    @GetMapping("/{promotionId}")
+    public ApiResponseDto<PromotionDetailDto> getPromotionById(@PathVariable Long promotionId) {
+        PromotionDetailDto detailDto = PromotionConverter.toDetailDto(promotionQueryService.getPromotionById(promotionId));
+        likeMusicQueryService.countLike(detailDto);
+        return ApiResponseDto.onSuccess(detailDto);
+    }
+
+    @Operation(summary = "프로모션 페이징 조회(비인증)", description = "로그인하지 않은 유저가 프로모션의 리스트를 페이징을 통해 조회합니다." +
+            "한페이지당 사이즈는 10개입니다.")
+    @ApiErrorCodeExample
+    @GetMapping
+    public ApiResponseDto<PromotionListDto> getPromotionList(@RequestParam(defaultValue = "0") int currentPage) {
+        Pageable pageable = PageRequest.of(currentPage, PageUtil.PROMOTION_SIZE);
+        return ApiResponseDto.onSuccess(
+                PromotionConverter.toListDto(
+                        promotionQueryService.getPaginationPromotion(pageable)
+                )
+        );
+    }
+    @Operation(summary = "프로모션 페이징 조회(인증🔑)", description = "프로모션의 리스트를 페이징을 통해 조회합니다." +
+            "한페이지당 사이즈는 10개입니다.")
+    @ApiErrorCodeExample
+    @GetMapping
+    public ApiResponseDto<PromotionListDto> getPromotionList(@RequestParam(defaultValue = "0") int currentPage) {
+        Pageable pageable = PageRequest.of(currentPage, PageUtil.PROMOTION_SIZE);
+        return ApiResponseDto.onSuccess(
+                PromotionConverter.toListDto(
+                        promotionQueryService.getPaginationPromotion(pageable)
+                )
+        );
+    }
+
+}

--- a/src/main/java/com/bandit/domain/board/controller/PromotionApiV2Controller.java
+++ b/src/main/java/com/bandit/domain/board/controller/PromotionApiV2Controller.java
@@ -20,6 +20,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
+import static com.bandit.global.annotation.api.PredefinedErrorStatus.AUTH;
+
 @Tag(name = "Promotion API V2", description = "프로모션 API V2")
 @ApiResponse(responseCode = "2000", description = "성공")
 @RequestMapping("/api/v2/promotions")
@@ -46,10 +48,11 @@ public class PromotionApiV2Controller {
         likeMusicQueryService.countLike(detailDto);
         return ApiResponseDto.onSuccess(detailDto);
     }
+
     @Operation(summary = "프로모션 조회(인증🔑)", description = "로그인한 유저가 프로모션의 PK를 통해 글을 조회합니다.")
-    @ApiErrorCodeExample({
+    @ApiErrorCodeExample(value = {
             ErrorStatus.PROMOTION_NOT_FOUND
-    })
+    }, status = AUTH)
     @GetMapping("/{promotionId}/auth")
     public ApiResponseDto<PromotionDetailDto> getPromotionById_auth(@AuthUser Member member,
                                                                     @PathVariable Long promotionId) {
@@ -79,9 +82,10 @@ public class PromotionApiV2Controller {
                 false));
         return ApiResponseDto.onSuccess(listDto);
     }
+
     @Operation(summary = "프로모션 페이징 조회(인증🔑)", description = "프로모션의 리스트를 페이징을 통해 조회합니다." +
             "한페이지당 사이즈는 10개입니다.")
-    @ApiErrorCodeExample
+    @ApiErrorCodeExample(status = AUTH)
     @GetMapping("/auth")
     public ApiResponseDto<PromotionListDto> getPromotionList_auth(@AuthUser Member member,
                                                                   @RequestParam(defaultValue = "0") int currentPage) {

--- a/src/main/java/com/bandit/domain/board/converter/PromotionConverter.java
+++ b/src/main/java/com/bandit/domain/board/converter/PromotionConverter.java
@@ -74,4 +74,9 @@ public class PromotionConverter {
                 .totalCount(paginationGuest.getTotalElements())
                 .build();
     }
+
+    public static void setPromotionLikeInDto(PromotionSummaryDto dto, long count, boolean isLiked) {
+        dto.getBoardLikeDto().setCount(count);
+        dto.getBoardLikeDto().setLiked(isLiked);
+    }
 }

--- a/src/main/java/com/bandit/domain/board/converter/PromotionConverter.java
+++ b/src/main/java/com/bandit/domain/board/converter/PromotionConverter.java
@@ -79,4 +79,8 @@ public class PromotionConverter {
         dto.getBoardLikeDto().setCount(count);
         dto.getBoardLikeDto().setLiked(isLiked);
     }
+    public static void setPromotionLikeInDto(PromotionDetailDto dto, long count, boolean isLiked) {
+        dto.getBoardLikeDto().setCount(count);
+        dto.getBoardLikeDto().setLiked(isLiked);
+    }
 }

--- a/src/main/java/com/bandit/domain/board/dto/promotion/PromotionResponse.java
+++ b/src/main/java/com/bandit/domain/board/dto/promotion/PromotionResponse.java
@@ -1,5 +1,6 @@
 package com.bandit.domain.board.dto.promotion;
 
+import com.bandit.domain.like.dto.LikeResponse.BoardLikeDto;
 import com.bandit.domain.member.dto.MemberResponse;
 import com.bandit.domain.music.dto.MusicResponse;
 import com.bandit.domain.ticket.dto.guest.GuestResponse.GuestViewDto;
@@ -33,6 +34,7 @@ public class PromotionResponse {
         private String accountHolder;
         private String refundInfo;
         private MemberResponse writer;
+        private BoardLikeDto boardLikeDto;
 
         private List<MusicResponse> musicList;
         private List<String> imageList;
@@ -52,6 +54,7 @@ public class PromotionResponse {
         private String endTime;
         private int entranceFee;
         private MemberResponse writer;
+        private BoardLikeDto boardLikeDto;
     }
     @Data
     @Builder

--- a/src/main/java/com/bandit/domain/board/dto/promotion/PromotionResponse.java
+++ b/src/main/java/com/bandit/domain/board/dto/promotion/PromotionResponse.java
@@ -34,7 +34,8 @@ public class PromotionResponse {
         private String accountHolder;
         private String refundInfo;
         private MemberResponse writer;
-        private BoardLikeDto boardLikeDto;
+        @Builder.Default
+        private BoardLikeDto boardLikeDto = new BoardLikeDto();
 
         private List<MusicResponse> musicList;
         private List<String> imageList;
@@ -54,7 +55,8 @@ public class PromotionResponse {
         private String endTime;
         private int entranceFee;
         private MemberResponse writer;
-        private BoardLikeDto boardLikeDto;
+        @Builder.Default
+        private BoardLikeDto boardLikeDto = new BoardLikeDto();
     }
     @Data
     @Builder

--- a/src/main/java/com/bandit/domain/like/dto/LikeResponse.java
+++ b/src/main/java/com/bandit/domain/like/dto/LikeResponse.java
@@ -12,7 +12,8 @@ public class LikeResponse {
     @AllArgsConstructor
     public static class BoardLikeDto{
         private long count;
-        private boolean isLiked;
+        @Builder.Default
+        private boolean isLiked = false;
     }
     @Data
     @Builder
@@ -20,6 +21,7 @@ public class LikeResponse {
     @AllArgsConstructor
     public static class MusicLikeDto{
         private long count;
-        private boolean isLiked;
+        @Builder.Default
+        private boolean isLiked = false;
     }
 }

--- a/src/main/java/com/bandit/domain/like/dto/LikeResponse.java
+++ b/src/main/java/com/bandit/domain/like/dto/LikeResponse.java
@@ -1,0 +1,6 @@
+package com.bandit.domain.like.dto;
+
+public class LikeResponse {
+    private int count;
+    private boolean isLiked;
+}

--- a/src/main/java/com/bandit/domain/like/dto/LikeResponse.java
+++ b/src/main/java/com/bandit/domain/like/dto/LikeResponse.java
@@ -1,6 +1,25 @@
 package com.bandit.domain.like.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 public class LikeResponse {
-    private int count;
-    private boolean isLiked;
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BoardLikeDto{
+        private long count;
+        private boolean isLiked;
+    }
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MusicLikeDto{
+        private long count;
+        private boolean isLiked;
+    }
 }

--- a/src/main/java/com/bandit/domain/like/service/like_music/LikeMusicQueryService.java
+++ b/src/main/java/com/bandit/domain/like/service/like_music/LikeMusicQueryService.java
@@ -8,6 +8,8 @@ public interface LikeMusicQueryService {
 
     boolean isLiked(Long musicId, Member member);
 
+    void isLiked(PromotionDetailDto response, Member member);
+
     long countLike(Long musicId);
 
     void countLike(PromotionDetailDto response);

--- a/src/main/java/com/bandit/domain/like/service/like_music/LikeMusicQueryServiceImpl.java
+++ b/src/main/java/com/bandit/domain/like/service/like_music/LikeMusicQueryServiceImpl.java
@@ -19,6 +19,15 @@ public class LikeMusicQueryServiceImpl implements LikeMusicQueryService {
     }
 
     @Override
+    public void isLiked(PromotionDetailDto response, Member member) {
+        response.getMusicList().forEach(musicResponse -> {
+            musicResponse.getMusicLikeDto().setLiked(
+                    likeMusicRepository.existsByMusicIdAndMember(musicResponse.getId(), member)
+            );
+        });
+    }
+
+    @Override
     public long countLike(Long musicId) {
         return likeMusicRepository.countByMusicId(musicId);
     }
@@ -26,7 +35,9 @@ public class LikeMusicQueryServiceImpl implements LikeMusicQueryService {
     @Override
     public void countLike(PromotionDetailDto response) {
         response.getMusicList().forEach(musicResponse ->
-            musicResponse.setCount(likeMusicRepository.countByMusicId(musicResponse.getId()))
+            musicResponse.getMusicLikeDto().setCount(
+                    likeMusicRepository.countByMusicId(musicResponse.getId())
+            )
         );
     }
 }

--- a/src/main/java/com/bandit/domain/music/dto/MusicResponse.java
+++ b/src/main/java/com/bandit/domain/music/dto/MusicResponse.java
@@ -17,5 +17,6 @@ public class MusicResponse {
     private String artist;
     @JsonProperty(value = "isOpen")
     private boolean isOpen;
-    private MusicLikeDto musicLikeDto;
+    @Builder.Default
+    private MusicLikeDto musicLikeDto = new MusicLikeDto();
 }

--- a/src/main/java/com/bandit/domain/music/dto/MusicResponse.java
+++ b/src/main/java/com/bandit/domain/music/dto/MusicResponse.java
@@ -1,5 +1,6 @@
 package com.bandit.domain.music.dto;
 
+import com.bandit.domain.like.dto.LikeResponse.MusicLikeDto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,4 +18,5 @@ public class MusicResponse {
     private long count;
     @JsonProperty(value = "isOpen")
     private boolean isOpen;
+    private MusicLikeDto musicLikeDto;
 }

--- a/src/main/java/com/bandit/domain/music/dto/MusicResponse.java
+++ b/src/main/java/com/bandit/domain/music/dto/MusicResponse.java
@@ -15,7 +15,6 @@ public class MusicResponse {
     private Long id;
     private String title;
     private String artist;
-    private long count;
     @JsonProperty(value = "isOpen")
     private boolean isOpen;
     private MusicLikeDto musicLikeDto;

--- a/src/main/java/com/bandit/security/config/SecurityConfig.java
+++ b/src/main/java/com/bandit/security/config/SecurityConfig.java
@@ -133,6 +133,12 @@ public class SecurityConfig {
                 antMatcher("/api/kakao/**")
         );
         return requestMatchers.toArray(RequestMatcher[]::new);
+    }private RequestMatcher[] permitAllRequestV2() {
+        List<RequestMatcher> requestMatchers = List.of(
+                antMatcher("/api/v2/promotions"),
+                antMatcher("/api/v2/promotions/{promotionId}")
+        );
+        return requestMatchers.toArray(RequestMatcher[]::new);
     }
     private RequestMatcher[] additionalSwaggerRequests() {
         List<RequestMatcher> requestMatchers = List.of(

--- a/src/main/java/com/bandit/security/config/SecurityConfig.java
+++ b/src/main/java/com/bandit/security/config/SecurityConfig.java
@@ -82,6 +82,7 @@ public class SecurityConfig {
                             .requestMatchers(permitAllRequest()).permitAll()
                             .requestMatchers(additionalSwaggerRequests()).permitAll()
                             .requestMatchers(authRelatedEndpoints()).permitAll()
+                            .requestMatchers(permitAllRequestV2()).permitAll()
                             .anyRequest().authenticated();
 //                            .requestMatchers(authorizationAdmin()).hasRole("ADMIN")
 //                            .requestMatchers(authorizationDormant()).hasRole("DORMANT")

--- a/src/main/java/com/bandit/security/config/SecurityConfig.java
+++ b/src/main/java/com/bandit/security/config/SecurityConfig.java
@@ -137,7 +137,8 @@ public class SecurityConfig {
     }private RequestMatcher[] permitAllRequestV2() {
         List<RequestMatcher> requestMatchers = List.of(
                 antMatcher("/api/v2/promotions"),
-                antMatcher("/api/v2/promotions/{promotionId}")
+                antMatcher("/api/v2/promotions/{promotionId}"),
+                antMatcher("/api/v2/promotions/search")
         );
         return requestMatchers.toArray(RequestMatcher[]::new);
     }


### PR DESCRIPTION
## 🔎 Description
> 프로모션 좋아요 개수와 여부 & 셑리스트 좋아요 개수와 여부 데이터를 모두 프로모션 조회 시에 같이 가져오도록 함


## 🔗 Related Issue
- https://github.com/playQR/playQR.back/issues/97

## 🏷️ What type of PR is this?
- [x] ✨ Feature
- [x] ♻️ Code Refactor
- [ ] 🐛 Bug Fix
- [ ] 🚑 Hot Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] ⚡️ Performance Improvements
- [ ] ✅ Test
- [ ] 👷 CI
- [ ] 💚 CI Fix
